### PR TITLE
Don't remove leading zeros from master account ID

### DIFF
--- a/enableguardduty.py
+++ b/enableguardduty.py
@@ -118,13 +118,13 @@ if __name__ == '__main__':
     
     # Setup command line arguments
     parser = argparse.ArgumentParser(description='Link AWS Accounts to central GuardDuty Account')
-    parser.add_argument('--master_account', type=int, help="AccountId for Central AWS Account")
+    parser.add_argument('--master_account', type=str, help="AccountId for Central AWS Account")
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Path to CSV file in the format of accountId, email, ...')
     parser.add_argument('--assume_role', type=str, default='AWSCloudFormationStackSetExecutionRole', help="Role Name to assume in each account")
     args = parser.parse_args()
     
     # Validate master accountId
-    if not re.match(r'[0-9]{12}',str(args.master_account)):
+    if not re.match(r'[0-9]{12}',args.master_account):
         raise ValueError("Master AccountId is not valid")
     
     # Generate dict with account & email information


### PR DESCRIPTION
*Issue #, if available:*
Hello,

Sorry for not starting a discussion but the change is quite small so here goes.
I had a case where the master account ID started with a 0 (zero) and since the argument expected an int during the assignment the leading zero was removed and the account ID validation failed.
EXAMPLE:

[amazon-guardduty-multiaccount-scripts] (master)$ python enableguardduty.py --master_account 012345678901 --assume_role DummyRoleName accounts.csv
Traceback (most recent call last):
  File "enableguardduty.py", line 128, in <module>
    raise ValueError("Master AccountId is not valid")
ValueError: Master AccountId is not valid 

After the change I was able to execute the script successfully.

*Description of changes:*

1. I changed the argument to expect type string;
2. Removed unnecessary cast to string in the regex validation since it's already a string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
