### PR TITLE
Optionally specify regions to enable/disable

### DIFF
--- a/disableguardduty.py
+++ b/disableguardduty.py
@@ -106,6 +106,7 @@ if __name__ == '__main__':
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Path to CSV file containing the list of account IDs and Email addresses')
     parser.add_argument('--assume_role', type=str, required=True, help="Role Name to assume in each account")
     parser.add_argument('--delete_master', action='store_true', default=False, help="Delete the master Gd Detector")
+    parser.add_argument('--enabled_regions', type=str, help="comma separated list of regions to remove GuardDuty. If not specified, all available regions disabled")
     args = parser.parse_args()
     
     # Validate master accountId
@@ -130,7 +131,14 @@ if __name__ == '__main__':
     
     # Getting GuardDuty regions
     session = boto3.session.Session()
-    guardduty_regions = session.get_available_regions('guardduty')
+    guardduty_regions = []
+    if args.enabled_regions:
+        guardduty_regions = [str(item) for item in args.enabled_regions.split(',')]
+        print("Disabling members in these regions: {}".format(guardduty_regions))
+    else:
+        guardduty_regions = session.get_available_regions('guardduty')
+        print("Disabling members in all available GuardDuty regions {}".format(guardduty_regions))
+    
     
     master_session = assume_role(args.master_account, args.assume_role)
             

--- a/enableguardduty.py
+++ b/enableguardduty.py
@@ -121,8 +121,9 @@ if __name__ == '__main__':
     parser.add_argument('--master_account', type=str, required=True, help="AccountId for Central AWS Account")
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Path to CSV file containing the list of account IDs and Email addresses')
     parser.add_argument('--assume_role', type=str, required=True, help="Role Name to assume in each account")
+    parser.add_argument('--enabled_regions', type=str, help="comma separated list of regions to enable GuardDuty. If not specified, all available regions enabled")
     args = parser.parse_args()
-    
+
     # Validate master accountId
     if not re.match(r'[0-9]{12}',args.master_account):
         raise ValueError("Master AccountId is not valid")
@@ -148,7 +149,14 @@ if __name__ == '__main__':
     
     # Getting GuardDuty regions
     session = boto3.session.Session()
-    guardduty_regions = session.get_available_regions('guardduty')
+
+    guardduty_regions = []
+    if args.enabled_regions:
+        guardduty_regions = [str(item) for item in args.enabled_regions.split(',')]
+        print("Enabling detectors in these regions: {}".format(guardduty_regions))
+    else:
+        guardduty_regions = session.get_available_regions('guardduty')
+        print("Enabling detectors in all available GuardDuty regions {}".format(guardduty_regions))
     
     # Setting the invitationmessage
     gd_invite_message = 'Account {account} invites you to join GuardDuty.'.format(account=args.master_account)

--- a/enableguardduty.py
+++ b/enableguardduty.py
@@ -153,10 +153,10 @@ if __name__ == '__main__':
     guardduty_regions = []
     if args.enabled_regions:
         guardduty_regions = [str(item) for item in args.enabled_regions.split(',')]
-        print("Enabling detectors in these regions: {}".format(guardduty_regions))
+        print("Enabling members in these regions: {}".format(guardduty_regions))
     else:
         guardduty_regions = session.get_available_regions('guardduty')
-        print("Enabling detectors in all available GuardDuty regions {}".format(guardduty_regions))
+        print("Enabling members in all available GuardDuty regions {}".format(guardduty_regions))
     
     # Setting the invitationmessage
     gd_invite_message = 'Account {account} invites you to join GuardDuty.'.format(account=args.master_account)


### PR DESCRIPTION

*Description of changes:*
Added cli option to specify the regions to enable GuardDuty in. Sometimes it is desirable to choose which regions to enable or disable, rather than going for the full list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
