### PR TITLE
Updated Failed Response Section of enableguardduty

### DIFF
--- a/enableguardduty.py
+++ b/enableguardduty.py
@@ -399,8 +399,10 @@ if __name__ == '__main__':
         print("Failed Accounts")
         print("---------------------------------------------------------------")
         for account in failed_accounts:
-            print("{}: \n\t{}".format(
-                account.keys()[0],
-                account[account.keys()[0]]
-            ))
+            for id in account:
+
+                print("{}: \n\t{}".format(
+                id,
+                account[id]
+                ))
             print("---------------------------------------------------------------")

--- a/enableguardduty.py
+++ b/enableguardduty.py
@@ -400,7 +400,6 @@ if __name__ == '__main__':
         print("---------------------------------------------------------------")
         for account in failed_accounts:
             for id in account:
-
                 print("{}: \n\t{}".format(
                 id,
                 account[id]


### PR DESCRIPTION
*Issue*
When running the code with python 3.7 the Failed Account Section did not supply me with any information when in the console I can visibly see multiple accounts had Errors. After Investigation I found the issue with this which was how account.keys()[0] no longer works.

*Description of changes:*
Update for how Python now uses Dictionaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
