### PR TITLE
Fix type of master_account variable

### DIFF
--- a/disableguardduty.py
+++ b/disableguardduty.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     
     # Setup command line arguments
     parser = argparse.ArgumentParser(description='Link AWS Accounts to central GuardDuty Account')
-    parser.add_argument('--master_account', type=int, required=True, help="AccountId for Central AWS Account")
+    parser.add_argument('--master_account', type=str, required=True, help="AccountId for Central AWS Account")
     parser.add_argument('input_file', type=argparse.FileType('r'), help='Path to CSV file containing the list of account IDs and Email addresses')
     parser.add_argument('--assume_role', type=str, required=True, help="Role Name to assume in each account")
     parser.add_argument('--delete_master', action='store_true', default=False, help="Delete the master Gd Detector")


### PR DESCRIPTION
master_account variable was defined as int. By defining the var as int,
would cause issues when the account id started with '0'. For example an
account id with 0nnnnnnnnnnn, would become nnnnnnnnnnn. This whould fail
on the regex '[0-9]{12}', because the account id would be striped of the
leading 0, and only have 11 digits.
Changing the master_account to str solves the issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
